### PR TITLE
ansible_ssh_user -> ansible_user

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ the users.
 
 ### Installation
 
-This role requires at least Ansible `v1.9.0`. To install it, run:
+This role requires at least Ansible `v2.0.0`. To install it, run:
 
     ansible-galaxy install debops.atd
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,9 +21,9 @@ atd_enabled: True
 # List of default UNIX user accounts which are allowed to use :command:`at` and
 # :command:`batch` commands. If this list is empty and ``atd_allow`` is also empty, any
 # account is allowed to use these commands.
-atd_default_allow: [ '{{ (ansible_ssh_user
-                          if (ansible_ssh_user|d() and
-                              ansible_ssh_user != "root")
+atd_default_allow: [ '{{ (ansible_user
+                          if (ansible_user|d() and
+                              ansible_user != "root")
                           else lookup("env","USER")) }}' ]
 
 

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -13,7 +13,7 @@ the users.
 Installation
 ~~~~~~~~~~~~
 
-This role requires at least Ansible ``v1.9.0``. To install it, run::
+This role requires at least Ansible ``v2.0.0``. To install it, run::
 
     ansible-galaxy install debops.atd
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,7 +7,7 @@ galaxy_info:
   description: 'Install and configure atd service'
   company: 'DebOps'
   license: 'GNU General Public License v3'
-  min_ansible_version: '1.9.0'
+  min_ansible_version: '2.0.0'
   platforms:
   - name: Ubuntu
     versions:


### PR DESCRIPTION
Since Ansible 2.0 and higher where ansible_ssh_user is deprecated and replaced by ansible_user